### PR TITLE
Add "now" command

### DIFF
--- a/cmd/now.go
+++ b/cmd/now.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// nowCmd represents the now command
+var nowCmd = &cobra.Command{
+	Use:   "now",
+	Short: "Displays the current time in UTC",
+	Long: `Displays the current time in UTC in iso8601 format`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cTimeUTC := time.Now().UTC().Format(time.RFC3339)
+		cTime := time.Now().Format(time.RFC3339)
+		fmt.Println(cTimeUTC)
+		fmt.Println(cTime)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(nowCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// nowCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// nowCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,13 +29,9 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "tyme",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "A CLI application to work with Time",
+	Long: `Tyme is a dev tool to work with time related stuffs.
+			Hope it helps.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	//	Run: func(cmd *cobra.Command, args []string) { },


### PR DESCRIPTION
**Summary**
Added a new command `now` that returns the current time in GMT time zone and user's time zone.

**Usage**
```
tyme now
```

**Output**
```
2020-10-29T17:30:40Z
2020-10-29T23:15:40+05:45
```