### PR TITLE
Root command displays the current time as well.

### DIFF
--- a/cmd/now.go
+++ b/cmd/now.go
@@ -28,11 +28,15 @@ var nowCmd = &cobra.Command{
 	Short: "Displays the current time in UTC",
 	Long: `Displays the current time in UTC in iso8601 format`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cTimeUTC := time.Now().UTC().Format(time.RFC3339)
-		cTime := time.Now().Format(time.RFC3339)
-		fmt.Println(cTimeUTC)
-		fmt.Println(cTime)
+		currentTime()
 	},
+}
+
+func currentTime() {
+	cTimeUTC := time.Now().UTC().Format(time.RFC3339)
+	cTime := time.Now().Format(time.RFC3339)
+	fmt.Println(cTimeUTC)
+	fmt.Println(cTime)
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,10 +31,10 @@ var rootCmd = &cobra.Command{
 	Use:   "tyme",
 	Short: "A CLI application to work with Time",
 	Long: `Tyme is a dev tool to work with time related stuffs.
-			Hope it helps.`,
+Supposed to be developer friendly.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+	Run: func(cmd *cobra.Command, args []string) { currentTime() },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
**Summary**
Transferring the existing `now` command operation to default operation.
Now, `tyme` returns the current time in UTC and local time zone.