### PR TITLE
Add Unix time.

### DIFF
--- a/cmd/now.go
+++ b/cmd/now.go
@@ -33,10 +33,13 @@ var nowCmd = &cobra.Command{
 }
 
 func currentTime() {
-	cTimeUTC := time.Now().UTC().Format(time.RFC3339)
-	cTime := time.Now().Format(time.RFC3339)
-	fmt.Println(cTimeUTC)
-	fmt.Println(cTime)
+	now := time.Now()
+	cTimeUTC := now.UTC().Format(time.RFC3339)
+	cTime := now.Format(time.RFC3339)
+	zone, _ := now.Local().Zone()
+	fmt.Println("UTC : ", cTimeUTC)
+	fmt.Println(zone, " : ", cTime)
+	fmt.Println("Unix(seconds) : ", now.Unix())
 }
 
 func init() {


### PR DESCRIPTION
**Summary**
Display Unix time as well while running `tyme` and `tyme now` commands

**New Output**
```
UTC :  2020-10-31T18:08:44Z
+0545  :  2020-10-31T23:53:44+05:45
Unix(seconds) :  1604167724
```